### PR TITLE
modification de la mutation et de la reponse pour le forgotPassword

### DIFF
--- a/src/types/ResetPassword.graphql.js
+++ b/src/types/ResetPassword.graphql.js
@@ -11,12 +11,12 @@ input ResetPasswordInput {
 }
 
 type PasswordResetResponse {
-  success: Boolean
+  success: Boolean!
   message: String
 }
 
 type Mutation {
-  forgotPassword(input: ForgotPasswordInput!): PasswordResetResponse!
+  forgotPassword(email: String!): PasswordResetResponse
   resetPassword(input: ResetPasswordInput!): PasswordResetResponse!
 }
 


### PR DESCRIPTION
Cette correction est lié au bug qu'il ya dans la console hidora lors de l'agregation des schema, forgotPassword fait partie des mutations qui posent probleme.